### PR TITLE
feature/iamroles

### DIFF
--- a/iam_roles.tf
+++ b/iam_roles.tf
@@ -1,0 +1,42 @@
+
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_logs_policy" {
+  name = "lambda-logs-policy"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_rds_access" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}


### PR DESCRIPTION
### Creación de IAM Role para ejecución de función Lambda con permisos de acceso a logs y RDS

#### 🔧 Recursos creados:

- **`aws_iam_role.lambda_role`**:
  - Define un rol IAM que puede ser asumido por el servicio `lambda.amazonaws.com`.
  - Usa una política de confianza (assume role policy) con formato JSON.

- **`aws_iam_role_policy.lambda_logs_policy`**:
  - Asocia una política inline al rol para permitir:
    - Crear grupos y flujos de logs (`logs:CreateLogGroup`, `logs:CreateLogStream`)
    - Enviar eventos a CloudWatch Logs (`logs:PutLogEvents`).
  - Aplica a todos los recursos (`Resource: "*"`) por simplicidad en desarrollo.

- **`aws_iam_role_policy_attachment.lambda_rds_access`**:
  - Adjunta la política administrada de AWS `AmazonRDSFullAccess` al rol.
  - Permite que la Lambda interactúe con bases de datos RDS (lectura, escritura, configuración, etc.).