### PR TITLE
feat(front) configurar infraestructura del front usando cloudfront, s3 y clonacion del repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 .terraform.lock.hcl
 
 # Logs de errores
+
+# Ignora la carpeta .idea/

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,1 +1,75 @@
-# Agregar recurso correspondiente
+resource "aws_cloudfront_origin_access_control" "frontend_oac" {
+  name                              = "frontend-oac"
+  description                       = "Acceso de CloudFront a S3"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend_distribution" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id   = "s3-frontend"
+
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend_oac.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-frontend"
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "FrontendCloudFront"
+  }
+}
+
+resource "aws_s3_bucket_policy" "only_cloudfront" {
+  bucket = aws_s3_bucket.frontend.id
+
+  depends_on = [aws_cloudfront_distribution.frontend_distribution]
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipal",
+        Effect    = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.frontend.arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend_distribution.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/deploy_frontend.tf
+++ b/deploy_frontend.tf
@@ -1,1 +1,21 @@
-# Agregar recurso correspondiente
+resource "null_resource" "deploy_frontend" {
+  provisioner "local-exec" {
+    command = <<EOT
+      if [ -d "./front" ]; then
+        rm -rf ./front
+      fi
+
+      git clone https://github.com/Organization-vash/front.git
+
+      cd front
+      npm install
+      npm run build -- --configuration production --project gestion-servicio-frontend
+
+      aws s3 sync ./dist/gestion-servicio-frontend/browser/ s3://${aws_s3_bucket.frontend.bucket} --delete
+    EOT
+
+    interpreter = ["bash", "-c"]
+  }
+
+  depends_on = [aws_s3_bucket_policy.only_cloudfront]
+}

--- a/s3.tf
+++ b/s3.tf
@@ -1,1 +1,20 @@
- # Agregar recurso correspondiente
+resource "aws_s3_bucket" "frontend" {
+  bucket        = "entel-s3-bucket-21"
+  force_destroy = true
+
+  tags = {
+    Name        = "EntelFrontend"
+    Environment = "dev"
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+  error_document {
+    key = "index.html"
+  }
+}


### PR DESCRIPTION
Creación de recursos en AWS:

- aws_s3_bucket para almacenar los archivos del frontend.
- aws_s3_bucket_website_configuration para configurar el bucket como un sitio web estático.
- aws_cloudfront_origin_access_control y aws_cloudfront_distribution para distribuir el frontend mediante CloudFront.
- aws_s3_bucket_policy para permitir el acceso seguro desde CloudFront al bucket S3.

Configuración de un recurso null_resource con local-exec para:

- Clonar el repositorio del frontend desde GitHub.
- Instalar dependencias de Node.js y compilar el proyecto en modo producción.
- Sincronizar los archivos generados en dist/ hacia el bucket S3 utilizando AWS CLI.

Corrección de la ejecución de comandos en entorno Windows adaptando la provisión local para usar bash.

Solución de errores relacionados con disponibilidad del aws CLI en el entorno bash.

Organización del flujo de trabajo Git:

- Creación de la rama feature/frontend.
- Manejo adecuado de archivos no deseados (exclusión de la carpeta .idea mediante .gitignore).