### PR TITLE
feature/security_group

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,42 @@
+# Security Group para la base de datos RDS
+resource "aws_security_group" "rds_sg" {
+  name        = "rds-sg"
+  description = "Permite conexiones desde Lambda"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "rds-sg"
+  }
+}
+
+# Security Group para la Lambda
+resource "aws_security_group" "lambda_sg" {
+  name        = "lambda-sg"
+  description = "Permite a Lambda acceder a RDS"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "lambda-sg"
+  }
+}


### PR DESCRIPTION
Se agrega los Security Groups para habilitar la comunicación segura entre Lambda y RDS (PostgreSQL) dentro de la VPC:

- lambda_sg: este permite la salida total para que lamba acceda a recursos externos.
- rds_sg: este permite acceso para la entrada al puerto 5432 solo desde lamba_sg, restringiendo el acceso a la base de datos.