### PR TITLE
Refractor: network.tf

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -14,29 +14,38 @@ resource "aws_internet_gateway" "gw" {
   }
 }
 
-resource "aws_subnet" "public_1" {
+resource "aws_subnet" "private_1" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "entel-private-1"
+  }
+}
+
+resource "aws_subnet" "private_2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.12.0/24"
+  availability_zone = "us-east-1b"
+
+  tags = {
+    Name = "entel-private-2"
+  }
+}
+
+resource "aws_subnet" "nat_subnet" {
   vpc_id                  = aws_vpc.main.id
-  cidr_block              = "10.0.1.0/24"
+  cidr_block              = "10.0.100.0/24"
   availability_zone       = "us-east-1a"
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "entel-public-1"
+    Name = "nat-subnet"
   }
 }
 
-resource "aws_subnet" "public_2" {
-  vpc_id                  = aws_vpc.main.id
-  cidr_block              = "10.0.2.0/24"
-  availability_zone       = "us-east-1b"
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name = "entel-public-2"
-  }
-}
-
-resource "aws_route_table" "public_rt" {
+resource "aws_route_table" "nat_subnet_rt" {
   vpc_id = aws_vpc.main.id
 
   route {
@@ -45,16 +54,51 @@ resource "aws_route_table" "public_rt" {
   }
 
   tags = {
-    Name = "entel-public-rt"
+    Name = "nat-subnet-rt"
   }
 }
 
-resource "aws_route_table_association" "public_1_assoc" {
-  subnet_id      = aws_subnet.public_1.id
-  route_table_id = aws_route_table.public_rt.id
+resource "aws_route_table_association" "nat_subnet_assoc" {
+  subnet_id      = aws_subnet.nat_subnet.id
+  route_table_id = aws_route_table.nat_subnet_rt.id
 }
 
-resource "aws_route_table_association" "public_2_assoc" {
-  subnet_id      = aws_subnet.public_2.id
-  route_table_id = aws_route_table.public_rt.id
+resource "aws_eip" "nat_eip" {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-eip"
+  }
+}
+
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.nat_subnet.id
+
+  tags = {
+    Name = "entel-nat"
+  }
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.id
+  }
+
+  tags = {
+    Name = "entel-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_1_assoc" {
+  subnet_id      = aws_subnet.private_1.id
+  route_table_id = aws_route_table.private_rt.id
+}
+
+resource "aws_route_table_association" "private_2_assoc" {
+  subnet_id      = aws_subnet.private_2.id
+  route_table_id = aws_route_table.private_rt.id
 }


### PR DESCRIPTION
Se implementa una VPC con subredes privadas y una subred pública para el NAT Gateway, permitiendo salida a internet desde las privadas de forma segura.

Incluye:
- VPC y subredes (privadas y pública)
- Internet Gateway y NAT Gateway
- Tablas de rutas y asociaciones

